### PR TITLE
SWP-87550 upgrade version of node to the last allowed version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Used to create a pull request.'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'check-square'


### PR DESCRIPTION
I tried to upgrade to node18, but the liner failed and the [docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing) only specify node16 as a possible value.