### PR TITLE
[SWP-115677] Add PR_NUMBER as an action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ jobs:
 
 Note that this action uses the template file in your repository. So you need 'checkout' step if you specify template option.
 
+**output**
+
+- `PR_NUMBER`: The number of the result PR.
+
 ## Demo
 
 ![](./docs/screenshot.png)

--- a/dist/index.js
+++ b/dist/index.js
@@ -45725,6 +45725,9 @@ const gitPrRelease = __nccwpck_require__(2567);
       core.info(`${key}: ${releasePr[key]}`);
     }
   }
+
+  core.setOutput('PR_NUMBER', releasePr.number);
+
 })().catch((e) => {
   core.setFailed(e.message);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,9 @@ const gitPrRelease = require("./git-pr-release");
       core.info(`${key}: ${releasePr[key]}`);
     }
   }
+
+  core.setOutput('PR_NUMBER', releasePr.number);
+
 })().catch((e) => {
   core.setFailed(e.message);
 });


### PR DESCRIPTION
Exporting the PR_NUMBER as an action output which makes it available to be mapped into inputs of other actions to ensure they are decoupled.